### PR TITLE
Adding a new extractor to handle highlights from the Moon+Reader app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,76 @@
 # Obsidian Multi-Platform Book Highlight Importer
 
-This plugin pulls your highlights and annotations from various different reading sources into Obsidian. This plugin reconciles books based on ISBN or title, so if you read the same book on different devices this plugin will only create one note (per book) with all the highlights. 
+This plugin pulls your highlights and annotations from various different reading sources into Obsidian. This plugin reconciles books based on ISBN or title, so if you read the same book on different devices this plugin will only create one note (per book) with all the highlights.
 
 ### Currently supported data sources
-- [x] Kobo
-- [x] Apple Books (iBooks)
+
+-   [x] Kobo
+-   [x] Apple Books (iBooks)
 
 ### Why would I use this instead of kobo-highlights-importer / apple-books-highlights-plugin etc.?
+
 1. **Highlights/annotations of the same book made using different services will be reconciled and consolidated into one note.**
-2. **Note format is standardized regardless of reading platform.** Even if you do not read the same book across multiple services, you might read different books on different services. This plugin can still help you by getting all your annotations into one standard note format. 
+2. **Note format is standardized regardless of reading platform.** Even if you do not read the same book across multiple services, you might read different books on different services. This plugin can still help you by getting all your annotations into one standard note format.
 
 ## How to use
+
 1. Install the plugin, either from the Obsidian plugin library or by cloning this repo to `/your/vault/.obsidian/plugins/`.
-2. Enable the plugin on the `Community plugins` page. 
+2. Enable the plugin on the `Community plugins` page.
 3. Configure the plugin on the `Multiplatform Highlights Importer` page. Here you can enable the reading services you would like to extract from. Note that some extractor require additional configuration (see below).
 4. Trigger extraction by clicking the eBook icon in the sidebar or by using the `Import multiplatform highlights` command in the command palette.
 
 ### Extractor specific configuration
+
 #### Kobo
+
 You need to specify the path to your `KoboReader.sqlite` database. It is located in the `/.kobo` folder on your Kobo when you plug it in to your computer. On a Mac, this would be `/Volumes/KOBOeReader/.kobo/KoboReader.sqlite`.
 
 #### Apple Books (macOS only)
+
 No additional configuration is necessary beyond enabling the extractor on the `Multiplatform Highlights Importer` settings page. Note that this extractor only works on macOS.
 
+#### Moon+Reader
+
+Moon+Reader does not provide easy ways to retrieve highlight data, so I had to take advantage of its backup system.
+This requires an action from the user inside the app (there is an option to set Auto Backup daily, weekly or monthly).
+Inside the Moon+Reader app, go to the settings. Scroll all the way down and find the "Backup" button.
+
+You can choose to sync to your computer using the Dropbox, Google Drive, WebDAV or FTP method.
+Alternatively, you can choose a local folder and transfer it to your desktop by your own means.
+
+Finally, you'll have to specify the path to the folder containing your `.mrstd` file inside the plugin.
+
+##### Limitations
+
+Some information is missing compared to the other extractors.
+At the time of writing this, I didn't find a practical way to get the chapter names (I only get the chapter numbers).
+A lot of information concerning the book is also missing (isbn, etc.)
+
 ## Contributing
+
 I would really appreciate contributions, either to develop connections to new services or to improve the note generation process (or anything else you can think of)!.
 
 ### Architecture
-The modular architecture of this plugin is really what distinguishes this plugin from others in the space. 
-The highlight extraction logic contains three main elements: extractors, the aggregator, and the extraction loop. 
+
+The modular architecture of this plugin is really what distinguishes this plugin from others in the space.
+The highlight extraction logic contains three main elements: extractors, the aggregator, and the extraction loop.
 
 Extractors are modular components that extract highlights from a single specific service.
 They must conform to the `IExtractor` interface, which means that they must implement a function called `extractHighlights()` which returns a list of `IBookWithHighlights`.
-`IBookWithHighlights` is a simple data structure representing a book with both book metadata and a list of highlights from that book. 
+`IBookWithHighlights` is a simple data structure representing a book with both book metadata and a list of highlights from that book.
 
-The aggregator is responsible for accepting lists of `IBookWithHighlights`, performing reconciliation, and outputting markdown. 
+The aggregator is responsible for accepting lists of `IBookWithHighlights`, performing reconciliation, and outputting markdown.
 The aggregator implements a function `addBooks()` which accepts `[]IBookWithHighlights` from an extractor and adds them to the aggregator's internal map.
-This function also performs reconciliation so that duplicate entries are not added to the map if the same book is extracted by multiple extractors. 
-The aggregator implements a second function `outputMarkdown()` which adds markdown files to the Obsidian vault for each book in its internal map. 
-This function is called once we have finished extracting from all services. 
+This function also performs reconciliation so that duplicate entries are not added to the map if the same book is extracted by multiple extractors.
+The aggregator implements a second function `outputMarkdown()` which adds markdown files to the Obsidian vault for each book in its internal map.
+This function is called once we have finished extracting from all services.
 
-The extraction loop ties the extractors and the aggregator together to extract the highlights and pipe them into Obsidian. 
+The extraction loop ties the extractors and the aggregator together to extract the highlights and pipe them into Obsidian.
 This is the entry point when you run the `Import Book Highlights` command of this plugin.
-It is quite simple: we call on each enabled extractor to produce highlights and pipe those highlights into the aggregator. 
+It is quite simple: we call on each enabled extractor to produce highlights and pipe those highlights into the aggregator.
 Once we've done this for each extractor, we ask the aggregator to output markdown for all the books.
-In pseudocode, the main extraction loop looks something like this: 
+In pseudocode, the main extraction loop looks something like this:
+
 ```
 for (extractor of extractors) {
 	booksWithHighlights = extractor.extractHighlights()
@@ -54,28 +80,32 @@ aggregator.outputMarkdown()
 ```
 
 ### Why you should contribute to this plugin instead of writing your own
+
 If you're thinking of writing your own plugin to do something with book annotations/highlights, it's likely for one of two reasons:
-1) You want to import highlights from a service which does not currently have a plugin.
-2) You don't like the files that an existing plugin creates and you want to create markdown files from highlights in a wildly different way. 
+
+1. You want to import highlights from a service which does not currently have a plugin.
+2. You don't like the files that an existing plugin creates and you want to create markdown files from highlights in a wildly different way.
 
 In both cases, I would argue that you would be better off contributing to this plugin instead of writing your own.
-If you fall into camp (1), you can simply create an extractor for your service, which will require you to only write the code to extract from your service. 
-The `IExtractor` interface is simple, and only requires you to implement one 
-By implementing an extractor, you get all the rest of the functionality (reconciliation between services, Markdown formatting and output) for free. 
+If you fall into camp (1), you can simply create an extractor for your service, which will require you to only write the code to extract from your service.
+The `IExtractor` interface is simple, and only requires you to implement one
+By implementing an extractor, you get all the rest of the functionality (reconciliation between services, Markdown formatting and output) for free.
 It's less work for you to create an extractor than to implement a whole plugin from scratch.
 
-If you fall into camp (2), I'd make the same argument as (1) but in reverse. 
-If you want to output markdown in a specific way, please build that in as an optional functionality on the aggregator. 
-By extending the aggregator, which already maintains a map of books and highlights, you won't have to worry about sourcing the data at all. 
-This means less work for you; you can focus your energies exclusively on writing code to output the files exactly the way you want them. 
+If you fall into camp (2), I'd make the same argument as (1) but in reverse.
+If you want to output markdown in a specific way, please build that in as an optional functionality on the aggregator.
+By extending the aggregator, which already maintains a map of books and highlights, you won't have to worry about sourcing the data at all.
+This means less work for you; you can focus your energies exclusively on writing code to output the files exactly the way you want them.
 
 ### Future work
-- Make extractor settings modular
-- Support for article services (Pocket, Zotero)
-- Specify different destination folders for different services (reconcile at the folder level, ie Kobo and Apple Books should output to the `Books` folder while Pocket and Zotero should output to the `Articles` folder)
-- Specify destination folders based on tags
-- More customization of note format
+
+-   Make extractor settings modular
+-   Support for article services (Pocket, Zotero)
+-   Specify different destination folders for different services (reconcile at the folder level, ie Kobo and Apple Books should output to the `Books` folder while Pocket and Zotero should output to the `Articles` folder)
+-   Specify destination folders based on tags
+-   More customization of note format
 
 ## Acknowledgements
-I built this plugin by forking [obsidian-kobo-highlights-import](https://github.com/OGKevin/obsidian-kobo-highlights-import) because I wanted Kobo support and I liked how their output notes grouped annotations by chapter. 
-I also looked at the code for [obsidian-apple-books-highlight-plugin](https://github.com/bandantonio/obsidian-apple-books-highlights-plugin) to build the Apple Books plugin. Thank you to the creators of those plugins. 
+
+I built this plugin by forking [obsidian-kobo-highlights-import](https://github.com/OGKevin/obsidian-kobo-highlights-import) because I wanted Kobo support and I liked how their output notes grouped annotations by chapter.
+I also looked at the code for [obsidian-apple-books-highlight-plugin](https://github.com/bandantonio/obsidian-apple-books-highlights-plugin) to build the Apple Books plugin. Thank you to the creators of those plugins.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"@popperjs/core": "2.11.8",
 				"@types/better-sqlite3": "7.6.9",
+				"adm-zip": "^0.5.16",
 				"moment": "2.30.1",
 				"sanitize-filename-ts": "1.0.2",
 				"sql.js": "1.8.0",
@@ -1546,6 +1547,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/adm-zip": {
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+			"integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0"
 			}
 		},
 		"node_modules/aggregate-error": {
@@ -5489,6 +5499,11 @@
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
 			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
 			"dev": true
+		},
+		"adm-zip": {
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+			"integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ=="
 		},
 		"aggregate-error": {
 			"version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 	"dependencies": {
 		"@popperjs/core": "2.11.8",
 		"@types/better-sqlite3": "7.6.9",
+		"adm-zip": "^0.5.16",
 		"moment": "2.30.1",
 		"sanitize-filename-ts": "1.0.2",
 		"sql.js": "1.8.0",

--- a/src/extract/moonreader.ts
+++ b/src/extract/moonreader.ts
@@ -1,0 +1,325 @@
+import { IExtractor } from "../interfaces/IExtractor";
+import { KoboHighlightsImporterSettings } from "../settings/Settings";
+import { IBook, IBookWithHighlights } from "../interfaces/IBook";
+import SqlJs, { Database } from "sql.js";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error
+import uint8array from "../binaries/sql-wasm.wasm";
+import fs from "fs";
+import path from "path";
+import { IHighlight } from "../interfaces/IHighlight";
+import { Notice } from "obsidian";
+import AdmZip from "adm-zip";
+
+export class MoonReaderExtractor implements IExtractor {
+	name = "MoonReader";
+	private tempDirectories: string[] = [];
+
+	async extractHighlights(
+		settings: KoboHighlightsImporterSettings
+	): Promise<IBookWithHighlights[]> {
+		try {
+			this.tempDirectories = [];
+			const SQLEngine = await SqlJs({
+				wasmBinary: uint8array.buffer,
+			});
+
+			// Since we rely on the Moon+Reader backup files, we can't be sure where the database is located.
+			// We'll search for it in the specified directory.
+			const dbFilePath = await this.findMoonReaderDbFile(
+				settings.moonreaderSqlitePath,
+				SQLEngine
+			);
+
+			if (!dbFilePath) {
+				new Notice(
+					"MoonReader database file not found. Please check the path."
+				);
+				return [];
+			}
+
+			const fileBuffer = fs.readFileSync(dbFilePath);
+			const db = new SQLEngine.Database(fileBuffer);
+
+			const highlights = await this.getAllHighlights(db);
+
+			const bookMap = new Map<string, IBook>();
+			const highlightMap = new Map<string, IHighlight[]>();
+
+			for (const highlight of highlights) {
+				const bookTitle = (
+					highlight.book || "Unknown Title"
+				).toString();
+
+				if (!bookMap.has(bookTitle)) {
+					bookMap.set(bookTitle, {
+						title: bookTitle,
+						author: highlight.book_author || "Unknown Author",
+						description: highlight.book_description || "",
+						isbn: undefined,
+						dateLastRead: new Date(
+							parseInt(highlight.time) || Date.now()
+						),
+					});
+				}
+
+				if (!highlightMap.has(bookTitle)) {
+					highlightMap.set(bookTitle, []);
+				}
+
+				if (!highlight.original && !highlight.bookmark) {
+					continue;
+				}
+
+				const highlightText =
+					highlight.original || highlight.bookmark || "";
+
+				highlightMap.get(bookTitle)?.push({
+					bookmarkId: highlight._id.toString(),
+					chapterTitle:
+						highlight.lastChapter.toString() || "Unknown Chapter",
+					text: highlightText,
+					note: highlight.note || "",
+					dateCreated: new Date(
+						parseInt(highlight.time) || Date.now()
+					),
+				});
+			}
+
+			const output: IBookWithHighlights[] = [];
+
+			bookMap.forEach((book, title) => {
+				const bookHighlights = highlightMap.get(title) || [];
+				if (bookHighlights.length > 0) {
+					output.push({
+						book: book,
+						highlights: bookHighlights,
+					});
+				}
+			});
+
+			return output;
+		} catch (error) {
+			console.error("Error extracting MoonReader highlights:", error);
+			new Notice(
+				"Failed to extract MoonReader highlights. Check the console for details."
+			);
+			return [];
+		} finally {
+			this.cleanupTempDirectories();
+		}
+	}
+
+	private cleanupTempDirectories(): void {
+		for (const dir of this.tempDirectories) {
+			try {
+				if (dir && fs.existsSync(dir)) {
+					fs.rmSync(dir, { recursive: true, force: true });
+					console.log(`Cleaned up temporary directory: ${dir}`);
+				}
+			} catch (e) {
+				console.error("Error cleaning up temporary directories:", e);
+			}
+			this.tempDirectories = [];
+		}
+	}
+
+	private async findMoonReaderDbFile(
+		directoryPath: string,
+		SQLEngine: any
+	): Promise<string | null> {
+		try {
+			const files = fs.readdirSync(directoryPath);
+			let tempFilePath = directoryPath;
+			const subDir = "com.flyersoft.moonreader";
+
+			const mrstdFiles = files.filter((file) => file.endsWith(".mrstd"));
+
+			if (mrstdFiles.length > 0) {
+				mrstdFiles.sort().reverse();
+
+				for (const mrstdFile of mrstdFiles) {
+					const mrstdPath = path.join(directoryPath, mrstdFile);
+					try {
+						const tempDir = await this.extractMrstdArchive(
+							mrstdPath
+						);
+
+						if (tempDir) {
+							this.tempDirectories.push(tempDir);
+							tempFilePath = tempDir;
+						}
+					} catch (e) {
+						console.error(
+							`Failed to process backup file ${mrstdPath}:`,
+							e
+						);
+						continue;
+					}
+				}
+			}
+
+			const SQLITE_HEADER = "SQLite format 3";
+			const finalDirectoryPath = path.join(tempFilePath, subDir);
+			const exportedFiles = fs.readdirSync(finalDirectoryPath);
+
+			for (const file of exportedFiles) {
+				const filePath = path.join(finalDirectoryPath, file);
+
+				if (fs.statSync(filePath).isDirectory()) {
+					continue;
+				}
+
+				try {
+					// Read the first 16 bytes to check SQLite signature
+					const fd = fs.openSync(filePath, "r");
+					const buffer = Buffer.alloc(16);
+					fs.readSync(fd, buffer, 0, 16, 0);
+					fs.closeSync(fd);
+
+					const header = buffer.toString("utf-8", 0, 15);
+					if (header === SQLITE_HEADER) {
+						// It's a SQLite file, check if it has the right tables
+						const db = new SQLEngine.Database(
+							fs.readFileSync(filePath)
+						);
+
+						try {
+							const tables = this.listTables(db);
+							if (tables.includes("notes")) {
+								console.log(
+									`Found MoonReader database: ${filePath}`
+								);
+								return filePath;
+							}
+						} catch (e) {
+							// Not the right database, try the next file
+							continue;
+						}
+					}
+				} catch (e) {
+					// Skip files that can't be read or aren't valid SQLite
+					continue;
+				}
+			}
+
+			return null;
+		} catch (error) {
+			console.error("Error searching for MoonReader database:", error);
+			return null;
+		}
+	}
+
+	private async extractMrstdArchive(
+		archivePath: string
+	): Promise<string | null> {
+		try {
+			const basename = path.basename(archivePath, ".mrstd");
+			const tempDir = path.join(
+				path.dirname(archivePath),
+				`temp_${basename}`
+			);
+
+			try {
+				if (!fs.existsSync(tempDir)) {
+					fs.mkdirSync(tempDir, { recursive: true });
+				}
+				const zip = new AdmZip(archivePath);
+				zip.extractAllTo(tempDir, true);
+			} catch (e) {
+				console.error(`Failed to extract archive ${archivePath}:`, e);
+				return null;
+			}
+
+			return tempDir;
+		} catch (error) {
+			console.error(`Error extracting archive ${archivePath}:`, error);
+			return null;
+		}
+	}
+
+	private listTables(db: Database): string[] {
+		try {
+			const tables: string[] = [];
+			const stmt = db.prepare(
+				"SELECT name FROM sqlite_master WHERE type='table'"
+			);
+
+			while (stmt.step()) {
+				const row = stmt.getAsObject();
+				if (row.name) {
+					tables.push(row.name.toString());
+				}
+			}
+
+			stmt.free();
+			return tables;
+		} catch (e) {
+			console.error("Error listing tables:", e);
+			return [];
+		}
+	}
+
+	private async getAllHighlights(db: Database): Promise<any[]> {
+		const hasBookAuthor = this.checkTableExists(db, "books");
+
+		// Build the query based on the actual schema
+		let query =
+			"SELECT n.* FROM notes n WHERE n.book IS NOT NULL ORDER BY n.time DESC";
+
+		// If books table exists, join with it
+		if (hasBookAuthor) {
+			query = `
+                SELECT 
+                    n.*,
+                    b.author as book_author,
+                    b.description as book_description
+                FROM notes n
+                LEFT JOIN books b ON n.book = b.book
+                WHERE n.book IS NOT NULL
+                ORDER BY n.time DESC
+            `;
+		}
+
+		try {
+			const statement = db.prepare(query);
+			const results: any[] = [];
+
+			while (statement.step()) {
+				const row = statement.getAsObject();
+				results.push(row);
+			}
+
+			statement.free();
+			return results;
+		} catch (error) {
+			console.error("Error executing query:", error);
+			throw error;
+		}
+	}
+
+	private checkTableExists(db: Database, tableName: string): boolean {
+		try {
+			const stmt = db.prepare(
+				"SELECT name FROM sqlite_master WHERE type='table' AND name=?"
+			);
+			stmt.bind([tableName]);
+			const exists = stmt.step();
+			stmt.free();
+			return exists;
+		} catch (e) {
+			return false;
+		}
+	}
+
+	// Not used for now, but could be useful in the future
+
+	// private getHighlightColorName(colorCode: number): string {
+	// 	if (colorCode === 1996532479) return "yellow";
+	// 	if (colorCode === -3368512) return "green";
+	// 	if (colorCode === -3373624) return "blue";
+	// 	if (colorCode === -3621789) return "red";
+	// 	if (colorCode === -6543440) return "purple";
+	// 	return "default";
+	// }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,73 +1,51 @@
-import { addIcon, App, Notice, Plugin } from "obsidian";
-import {
-	DEFAULT_SETTINGS,
-	KoboHighlightsImporterSettings,
-	KoboHighlightsImporterSettingsTab,
-} from "./settings/Settings";
-import { KoboExtractor } from "./extract/kobo";
-import { Aggregator } from "./aggregator";
-import { AppleBooksExtractor } from "./extract/apple_books";
+import {addIcon, App, Notice, Plugin} from 'obsidian';
+import { DEFAULT_SETTINGS, KoboHighlightsImporterSettings, KoboHighlightsImporterSettingsTab } from './settings/Settings';
+import {KoboExtractor} from "./extract/kobo";
+import {Aggregator} from "./aggregator";
+import {AppleBooksExtractor} from "./extract/apple_books";
 import { MoonReaderExtractor } from "./extract/moonreader";
 
-const EREADER_ICON_PATH = `<path stroke="currentColor" fill="currentColor" d="M 68.15625 55.882812 C 67.609375 54.335938 66.207031 53.367188 64.566406 53.367188 L 62.085938 53.367188 L 62.085938 8.894531 C 62.085938 4.367188 58.457031 0.773438 53.886719 0.773438 L 9.761719 0.773438 C 4.910156 0.773438 0.78125 4.859375 0.78125 9.667969 L 0.78125 80.4375 C 0.78125 85.039062 5.058594 88.945312 9.664062 88.945312 L 54.261719 88.945312 C 54.734375 88.945312 55.148438 89.324219 55.113281 89.792969 C 55.074219 90.28125 54.664062 90.492188 54.179688 90.492188 L 36.410156 90.492188 L 49.980469 98.226562 L 81.21875 98.226562 Z M 32.039062 85.15625 C 30.789062 85.15625 29.851562 84.226562 29.851562 82.992188 C 29.851562 81.8125 30.851562 80.824219 32.039062 80.824219 C 33.289062 80.824219 34.226562 81.753906 34.226562 82.988281 C 34.1875 84.226562 33.289062 85.15625 32.039062 85.15625 Z M 56.230469 53.367188 L 48.554688 53.367188 C 46.484375 53.367188 44.730469 55.183594 44.730469 57.234375 C 44.730469 59.285156 46.484375 61.101562 48.554688 61.101562 L 56.289062 61.101562 L 56.289062 77.34375 L 7.027344 77.34375 L 7.027344 11.988281 L 56.230469 11.988281 Z M 45.257812 15.898438 L 45.257812 43.113281 C 43.390625 43.113281 41.882812 44.605469 41.882812 46.453125 C 41.882812 48.300781 43.390625 49.796875 45.257812 49.796875 L 45.257812 51.09375 L 21.042969 51.09375 L 21.042969 51.078125 C 18.550781 50.980469 16.542969 48.949219 16.542969 46.453125 C 16.542969 46.242188 16.601562 20.539062 16.601562 20.539062 C 16.601562 17.988281 18.707031 15.902344 21.285156 15.902344 L 45.257812 15.902344 Z M 42.066406 43.082031 L 20.957031 43.125 C 19.21875 43.253906 17.839844 44.691406 17.839844 46.4375 C 17.839844 48.285156 19.363281 49.792969 21.226562 49.78125 L 42.027344 49.78125 C 41.144531 48.933594 40.574219 47.75 40.574219 46.4375 C 40.574219 45.113281 41.15625 43.929688 42.066406 43.082031 Z M 42.066406 43.082031 "/>`;
+const EREADER_ICON_PATH = `<path stroke="currentColor" fill="currentColor" d="M 68.15625 55.882812 C 67.609375 54.335938 66.207031 53.367188 64.566406 53.367188 L 62.085938 53.367188 L 62.085938 8.894531 C 62.085938 4.367188 58.457031 0.773438 53.886719 0.773438 L 9.761719 0.773438 C 4.910156 0.773438 0.78125 4.859375 0.78125 9.667969 L 0.78125 80.4375 C 0.78125 85.039062 5.058594 88.945312 9.664062 88.945312 L 54.261719 88.945312 C 54.734375 88.945312 55.148438 89.324219 55.113281 89.792969 C 55.074219 90.28125 54.664062 90.492188 54.179688 90.492188 L 36.410156 90.492188 L 49.980469 98.226562 L 81.21875 98.226562 Z M 32.039062 85.15625 C 30.789062 85.15625 29.851562 84.226562 29.851562 82.992188 C 29.851562 81.8125 30.851562 80.824219 32.039062 80.824219 C 33.289062 80.824219 34.226562 81.753906 34.226562 82.988281 C 34.1875 84.226562 33.289062 85.15625 32.039062 85.15625 Z M 56.230469 53.367188 L 48.554688 53.367188 C 46.484375 53.367188 44.730469 55.183594 44.730469 57.234375 C 44.730469 59.285156 46.484375 61.101562 48.554688 61.101562 L 56.289062 61.101562 L 56.289062 77.34375 L 7.027344 77.34375 L 7.027344 11.988281 L 56.230469 11.988281 Z M 45.257812 15.898438 L 45.257812 43.113281 C 43.390625 43.113281 41.882812 44.605469 41.882812 46.453125 C 41.882812 48.300781 43.390625 49.796875 45.257812 49.796875 L 45.257812 51.09375 L 21.042969 51.09375 L 21.042969 51.078125 C 18.550781 50.980469 16.542969 48.949219 16.542969 46.453125 C 16.542969 46.242188 16.601562 20.539062 16.601562 20.539062 C 16.601562 17.988281 18.707031 15.902344 21.285156 15.902344 L 45.257812 15.902344 Z M 42.066406 43.082031 L 20.957031 43.125 C 19.21875 43.253906 17.839844 44.691406 17.839844 46.4375 C 17.839844 48.285156 19.363281 49.792969 21.226562 49.78125 L 42.027344 49.78125 C 41.144531 48.933594 40.574219 47.75 40.574219 46.4375 C 40.574219 45.113281 41.15625 43.929688 42.066406 43.082031 Z M 42.066406 43.082031 "/>`
 
 export default class KoboHighlightsImporter extends Plugin {
 	settings!: KoboHighlightsImporterSettings;
 
 	async onload() {
-		addIcon("e-reader", EREADER_ICON_PATH);
+		addIcon('e-reader', EREADER_ICON_PATH)
 		await this.loadSettings();
 
 		// This creates an icon in the left ribbon.
-		const KoboHighlightsImporterIconEl = this.addRibbonIcon(
-			"e-reader",
-			"Import book highlights",
-			() => {
-				this.extractHighlights()
-					.then(() => {
-						new Notice("Extracted highlights from books!");
-					})
-					.catch((e) => {
-						console.log(e);
-						new Notice(
-							"Something went wrong... Check console for more details."
-						);
-					});
-			}
-		);
+		const KoboHighlightsImporterIconEl = this.addRibbonIcon('e-reader', 'Import book highlights', () => {
+			this.extractHighlights().then(() => {
+				new Notice('Extracted highlights from books!')
+			}).catch(e => {
+				console.log(e)
+				new Notice('Something went wrong... Check console for more details.')
+			});
+		});
 		// Perform additional things with the ribbon
-		KoboHighlightsImporterIconEl.addClass("kobo-highlights-importer-icon");
+		KoboHighlightsImporterIconEl.addClass('kobo-highlights-importer-icon');
 
 		// This adds a simple command that can be triggered anywhere
 		this.addCommand({
-			id: "import-multiplatform-highlights",
-			name: "Import multiplatform highlights",
+			id: 'import-multiplatform-highlights',
+			name: 'Import multiplatform highlights',
 			callback: () => {
-				this.extractHighlights()
-					.then(() => {
-						new Notice("Extracted highlights from books!");
-					})
-					.catch((e) => {
-						console.log(e);
-						new Notice(
-							"Something went wrong... Check console for more details."
-						);
-					});
-			},
+				this.extractHighlights().then(() => {
+					new Notice('Extracted highlights from books!')
+				}).catch(e => {
+					console.log(e)
+					new Notice('Something went wrong... Check console for more details.')
+				});
+			}
 		});
 
 		// This adds a settings tab so the user can configure various aspects of the plugin
-		this.addSettingTab(
-			new KoboHighlightsImporterSettingsTab(this.app, this)
-		);
+		this.addSettingTab(new KoboHighlightsImporterSettingsTab(this.app, this));
 	}
 
 	async loadSettings() {
-		this.settings = Object.assign(
-			{},
-			DEFAULT_SETTINGS,
-			await this.loadData()
-		);
+		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
 	}
 
 	async saveSettings() {
@@ -75,31 +53,24 @@ export default class KoboHighlightsImporter extends Plugin {
 	}
 
 	async extractHighlights() {
-		const aggregator = new Aggregator();
+		const aggregator = new Aggregator()
 
 		if (this.settings.enableKobo) {
-			const koboHighlights = await new KoboExtractor().extractHighlights(
-				this.settings
-			);
-			aggregator.addBooks(koboHighlights);
+			const koboHighlights = await new KoboExtractor().extractHighlights(this.settings)
+			aggregator.addBooks(koboHighlights)
 		}
 
 		if (this.settings.enableAppleBooks) {
-			const appleBooksHighlights =
-				await new AppleBooksExtractor().extractHighlights(
-					this.settings
-				);
-			aggregator.addBooks(appleBooksHighlights);
+			const appleBooksHighlights = await new AppleBooksExtractor().extractHighlights(this.settings)
+			aggregator.addBooks(appleBooksHighlights)
 		}
 
 		if (this.settings.enableMoonreader) {
-			const moonReaderHighlights =
-				await new MoonReaderExtractor().extractHighlights(
-					this.settings
-				);
+			const moonReaderHighlights = await new MoonReaderExtractor().extractHighlights(this.settings);
 			aggregator.addBooks(moonReaderHighlights);
 		}
 
-		await aggregator.outputMarkdown(this.settings, this.app);
+		await aggregator.outputMarkdown(this.settings, this.app)
 	}
+
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,50 +1,73 @@
-import {addIcon, App, Notice, Plugin} from 'obsidian';
-import { DEFAULT_SETTINGS, KoboHighlightsImporterSettings, KoboHighlightsImporterSettingsTab } from './settings/Settings';
-import {KoboExtractor} from "./extract/kobo";
-import {Aggregator} from "./aggregator";
-import {AppleBooksExtractor} from "./extract/apple_books";
+import { addIcon, App, Notice, Plugin } from "obsidian";
+import {
+	DEFAULT_SETTINGS,
+	KoboHighlightsImporterSettings,
+	KoboHighlightsImporterSettingsTab,
+} from "./settings/Settings";
+import { KoboExtractor } from "./extract/kobo";
+import { Aggregator } from "./aggregator";
+import { AppleBooksExtractor } from "./extract/apple_books";
+import { MoonReaderExtractor } from "./extract/moonreader";
 
-const EREADER_ICON_PATH = `<path stroke="currentColor" fill="currentColor" d="M 68.15625 55.882812 C 67.609375 54.335938 66.207031 53.367188 64.566406 53.367188 L 62.085938 53.367188 L 62.085938 8.894531 C 62.085938 4.367188 58.457031 0.773438 53.886719 0.773438 L 9.761719 0.773438 C 4.910156 0.773438 0.78125 4.859375 0.78125 9.667969 L 0.78125 80.4375 C 0.78125 85.039062 5.058594 88.945312 9.664062 88.945312 L 54.261719 88.945312 C 54.734375 88.945312 55.148438 89.324219 55.113281 89.792969 C 55.074219 90.28125 54.664062 90.492188 54.179688 90.492188 L 36.410156 90.492188 L 49.980469 98.226562 L 81.21875 98.226562 Z M 32.039062 85.15625 C 30.789062 85.15625 29.851562 84.226562 29.851562 82.992188 C 29.851562 81.8125 30.851562 80.824219 32.039062 80.824219 C 33.289062 80.824219 34.226562 81.753906 34.226562 82.988281 C 34.1875 84.226562 33.289062 85.15625 32.039062 85.15625 Z M 56.230469 53.367188 L 48.554688 53.367188 C 46.484375 53.367188 44.730469 55.183594 44.730469 57.234375 C 44.730469 59.285156 46.484375 61.101562 48.554688 61.101562 L 56.289062 61.101562 L 56.289062 77.34375 L 7.027344 77.34375 L 7.027344 11.988281 L 56.230469 11.988281 Z M 45.257812 15.898438 L 45.257812 43.113281 C 43.390625 43.113281 41.882812 44.605469 41.882812 46.453125 C 41.882812 48.300781 43.390625 49.796875 45.257812 49.796875 L 45.257812 51.09375 L 21.042969 51.09375 L 21.042969 51.078125 C 18.550781 50.980469 16.542969 48.949219 16.542969 46.453125 C 16.542969 46.242188 16.601562 20.539062 16.601562 20.539062 C 16.601562 17.988281 18.707031 15.902344 21.285156 15.902344 L 45.257812 15.902344 Z M 42.066406 43.082031 L 20.957031 43.125 C 19.21875 43.253906 17.839844 44.691406 17.839844 46.4375 C 17.839844 48.285156 19.363281 49.792969 21.226562 49.78125 L 42.027344 49.78125 C 41.144531 48.933594 40.574219 47.75 40.574219 46.4375 C 40.574219 45.113281 41.15625 43.929688 42.066406 43.082031 Z M 42.066406 43.082031 "/>`
+const EREADER_ICON_PATH = `<path stroke="currentColor" fill="currentColor" d="M 68.15625 55.882812 C 67.609375 54.335938 66.207031 53.367188 64.566406 53.367188 L 62.085938 53.367188 L 62.085938 8.894531 C 62.085938 4.367188 58.457031 0.773438 53.886719 0.773438 L 9.761719 0.773438 C 4.910156 0.773438 0.78125 4.859375 0.78125 9.667969 L 0.78125 80.4375 C 0.78125 85.039062 5.058594 88.945312 9.664062 88.945312 L 54.261719 88.945312 C 54.734375 88.945312 55.148438 89.324219 55.113281 89.792969 C 55.074219 90.28125 54.664062 90.492188 54.179688 90.492188 L 36.410156 90.492188 L 49.980469 98.226562 L 81.21875 98.226562 Z M 32.039062 85.15625 C 30.789062 85.15625 29.851562 84.226562 29.851562 82.992188 C 29.851562 81.8125 30.851562 80.824219 32.039062 80.824219 C 33.289062 80.824219 34.226562 81.753906 34.226562 82.988281 C 34.1875 84.226562 33.289062 85.15625 32.039062 85.15625 Z M 56.230469 53.367188 L 48.554688 53.367188 C 46.484375 53.367188 44.730469 55.183594 44.730469 57.234375 C 44.730469 59.285156 46.484375 61.101562 48.554688 61.101562 L 56.289062 61.101562 L 56.289062 77.34375 L 7.027344 77.34375 L 7.027344 11.988281 L 56.230469 11.988281 Z M 45.257812 15.898438 L 45.257812 43.113281 C 43.390625 43.113281 41.882812 44.605469 41.882812 46.453125 C 41.882812 48.300781 43.390625 49.796875 45.257812 49.796875 L 45.257812 51.09375 L 21.042969 51.09375 L 21.042969 51.078125 C 18.550781 50.980469 16.542969 48.949219 16.542969 46.453125 C 16.542969 46.242188 16.601562 20.539062 16.601562 20.539062 C 16.601562 17.988281 18.707031 15.902344 21.285156 15.902344 L 45.257812 15.902344 Z M 42.066406 43.082031 L 20.957031 43.125 C 19.21875 43.253906 17.839844 44.691406 17.839844 46.4375 C 17.839844 48.285156 19.363281 49.792969 21.226562 49.78125 L 42.027344 49.78125 C 41.144531 48.933594 40.574219 47.75 40.574219 46.4375 C 40.574219 45.113281 41.15625 43.929688 42.066406 43.082031 Z M 42.066406 43.082031 "/>`;
 
 export default class KoboHighlightsImporter extends Plugin {
 	settings!: KoboHighlightsImporterSettings;
 
 	async onload() {
-		addIcon('e-reader', EREADER_ICON_PATH)
+		addIcon("e-reader", EREADER_ICON_PATH);
 		await this.loadSettings();
 
 		// This creates an icon in the left ribbon.
-		const KoboHighlightsImporterIconEl = this.addRibbonIcon('e-reader', 'Import book highlights', () => {
-			this.extractHighlights().then(() => {
-				new Notice('Extracted highlights from books!')
-			}).catch(e => {
-				console.log(e)
-				new Notice('Something went wrong... Check console for more details.')
-			});
-		});
+		const KoboHighlightsImporterIconEl = this.addRibbonIcon(
+			"e-reader",
+			"Import book highlights",
+			() => {
+				this.extractHighlights()
+					.then(() => {
+						new Notice("Extracted highlights from books!");
+					})
+					.catch((e) => {
+						console.log(e);
+						new Notice(
+							"Something went wrong... Check console for more details."
+						);
+					});
+			}
+		);
 		// Perform additional things with the ribbon
-		KoboHighlightsImporterIconEl.addClass('kobo-highlights-importer-icon');
+		KoboHighlightsImporterIconEl.addClass("kobo-highlights-importer-icon");
 
 		// This adds a simple command that can be triggered anywhere
 		this.addCommand({
-			id: 'import-multiplatform-highlights',
-			name: 'Import multiplatform highlights',
+			id: "import-multiplatform-highlights",
+			name: "Import multiplatform highlights",
 			callback: () => {
-				this.extractHighlights().then(() => {
-					new Notice('Extracted highlights from books!')
-				}).catch(e => {
-					console.log(e)
-					new Notice('Something went wrong... Check console for more details.')
-				});
-			}
+				this.extractHighlights()
+					.then(() => {
+						new Notice("Extracted highlights from books!");
+					})
+					.catch((e) => {
+						console.log(e);
+						new Notice(
+							"Something went wrong... Check console for more details."
+						);
+					});
+			},
 		});
 
 		// This adds a settings tab so the user can configure various aspects of the plugin
-		this.addSettingTab(new KoboHighlightsImporterSettingsTab(this.app, this));
+		this.addSettingTab(
+			new KoboHighlightsImporterSettingsTab(this.app, this)
+		);
 	}
 
 	async loadSettings() {
-		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+		this.settings = Object.assign(
+			{},
+			DEFAULT_SETTINGS,
+			await this.loadData()
+		);
 	}
 
 	async saveSettings() {
@@ -52,19 +75,31 @@ export default class KoboHighlightsImporter extends Plugin {
 	}
 
 	async extractHighlights() {
-		const aggregator = new Aggregator()
+		const aggregator = new Aggregator();
 
 		if (this.settings.enableKobo) {
-			const koboHighlights = await new KoboExtractor().extractHighlights(this.settings)
-			aggregator.addBooks(koboHighlights)
+			const koboHighlights = await new KoboExtractor().extractHighlights(
+				this.settings
+			);
+			aggregator.addBooks(koboHighlights);
 		}
 
 		if (this.settings.enableAppleBooks) {
-			const appleBooksHighlights = await new AppleBooksExtractor().extractHighlights(this.settings)
-			aggregator.addBooks(appleBooksHighlights)
+			const appleBooksHighlights =
+				await new AppleBooksExtractor().extractHighlights(
+					this.settings
+				);
+			aggregator.addBooks(appleBooksHighlights);
 		}
 
-		await aggregator.outputMarkdown(this.settings, this.app)
-	}
+		if (this.settings.enableMoonreader) {
+			const moonReaderHighlights =
+				await new MoonReaderExtractor().extractHighlights(
+					this.settings
+				);
+			aggregator.addBooks(moonReaderHighlights);
+		}
 
+		await aggregator.outputMarkdown(this.settings, this.app);
+	}
 }

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -1,4 +1,4 @@
-import { App, Notice, PluginSettingTab, Setting } from "obsidian";
+import {App, Notice, PluginSettingTab, Setting} from "obsidian";
 import KoboHighlightsImporter from "src/main";
 import { FileSuggestor } from "./suggestors/FileSuggestor";
 import { FolderSuggestor } from "./suggestors/FolderSuggestor";
@@ -37,48 +37,41 @@ export interface KoboHighlightsImporterSettings {
 }
 
 export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
-	constructor(public app: App, private plugin: KoboHighlightsImporter) {
-		super(app, plugin);
-	}
+    constructor(public app: App, private plugin: KoboHighlightsImporter) {
+        super(app, plugin);
+    }
 
-	display(): void {
-		this.containerEl.empty();
+    display(): void {
+        this.containerEl.empty();
 
-		new Setting(this.containerEl)
-			.setName("Highlight Extraction")
-			.setHeading();
-		this.containerEl.createEl("p", {
-			text: "Configure the data sources from which you will pull highlights.",
-		});
-		this.add_kobo_path();
-		this.add_apple_books();
-		this.add_moonreader_path();
+		new Setting(this.containerEl).setName('Highlight Extraction').setHeading();
+		this.containerEl.createEl('p', { text: "Configure the data sources from which you will pull highlights." })
+		this.add_kobo_path()
+		this.add_apple_books()
+		this.add_moonreader_path()
 
-		new Setting(this.containerEl).setName("Output").setHeading();
-		this.containerEl.createEl("p", {
-			text: "Configure how the highlights will output in Obsidian.",
-		});
-		this.add_destination_folder();
-		this.add_enable_creation_date();
-		this.add_date_format();
-		this.add_template_path();
-		this.add_sort_by_chapter_progress();
-		this.add_enable_callouts();
-		this.add_highlight_callouts_format();
-		this.add_annotation_callouts_format();
-	}
+		new Setting(this.containerEl).setName('Output').setHeading();
+		this.containerEl.createEl('p', { text: "Configure how the highlights will output in Obsidian." })
+        this.add_destination_folder();
+        this.add_enable_creation_date();
+        this.add_date_format();
+        this.add_template_path();
+        this.add_sort_by_chapter_progress();
+        this.add_enable_callouts();
+        this.add_highlight_callouts_format();
+        this.add_annotation_callouts_format();
+    }
 
 	add_kobo_path(): void {
 		new Setting(this.containerEl)
 			.setName("Enable Kobo extractor")
 			.addToggle((toggle) => {
-				toggle
-					.setValue(this.plugin.settings.enableKobo)
+				toggle.setValue(this.plugin.settings.enableKobo)
 					.onChange((value) => {
 						this.plugin.settings.enableKobo = value;
 						this.plugin.saveSettings();
-					});
-			});
+					})
+			})
 
 		new Setting(this.containerEl)
 			.setName("Kobo DB filepath")
@@ -90,15 +83,14 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						fs.access(value, fs.constants.R_OK, (err) => {
 							if (err) {
-								new Notice("Selected file is not readable");
+								new Notice('Selected file is not readable')
 							} else {
-								this.plugin.settings.koboSqlitePath = value;
+								this.plugin.settings.koboSqlitePath = value
 								this.plugin.saveSettings();
-								new Notice("Ready to extract!");
+								new Notice('Ready to extract!')
 							}
-						});
-					})
-			);
+						})
+					}));
 	}
 
 	add_apple_books(): void {
@@ -106,8 +98,7 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 			.setName("Enable Apple Books extractor")
 			.setDesc("Apple Books extraction is only compatible with macOS")
 			.addToggle((toggle) => {
-				toggle
-					.setValue(this.plugin.settings.enableAppleBooks)
+				toggle.setValue(this.plugin.settings.enableAppleBooks)
 					.onChange((value) => {
 						this.plugin.settings.enableAppleBooks = value;
 						this.plugin.saveSettings();
@@ -149,137 +140,128 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 			);
 	}
 
-	add_destination_folder(): void {
-		new Setting(this.containerEl)
-			.setName("Destination folder")
-			.setDesc("Where to save your imported highlights")
-			.addSearch((cb) => {
-				new FolderSuggestor(this.app, cb.inputEl);
-				cb.setPlaceholder("Example: folder1/folder2")
-					.setValue(this.plugin.settings.storageFolder)
-					.onChange((newFolder) => {
-						this.plugin.settings.storageFolder = newFolder;
-						this.plugin.saveSettings();
-					});
-			});
-	}
+    add_destination_folder(): void {
+        new Setting(this.containerEl)
+            .setName('Destination folder')
+            .setDesc('Where to save your imported highlights')
+            .addSearch((cb) => {
+                new FolderSuggestor(this.app, cb.inputEl);
+                cb.setPlaceholder("Example: folder1/folder2")
+                    .setValue(this.plugin.settings.storageFolder)
+                    .onChange((newFolder) => {
+                        this.plugin.settings.storageFolder = newFolder;
+                        this.plugin.saveSettings();
+                    });
+            });
+    }
 
-	add_template_path(): void {
-		new Setting(this.containerEl)
-			.setName("Template Path")
-			.setDesc("Which template to use for extracted highlights")
-			.addSearch((cb) => {
-				new FileSuggestor(this.app, cb.inputEl);
-				cb.setPlaceholder("Example: folder1/template")
-					.setValue(this.plugin.settings.templatePath)
-					.onChange((newTemplatePath) => {
-						this.plugin.settings.templatePath = newTemplatePath;
-						this.plugin.saveSettings();
-					});
-			});
-	}
+    add_template_path(): void {
+        new Setting(this.containerEl)
+            .setName('Template Path')
+            .setDesc('Which template to use for extracted highlights')
+            .addSearch((cb) => {
+                new FileSuggestor(this.app, cb.inputEl);
+                cb.setPlaceholder("Example: folder1/template")
+                    .setValue(this.plugin.settings.templatePath)
+                    .onChange((newTemplatePath) => {
+                        this.plugin.settings.templatePath = newTemplatePath;
+                        this.plugin.saveSettings();
+                    });
+            });
+    }
 
-	add_enable_creation_date(): void {
-		new Setting(this.containerEl)
-			.setName("Add creation date")
-			.setDesc(
-				`If the exported higlights should include '- [[${this.plugin.settings.dateFormat}]]'`
-			)
-			.addToggle((cb) => {
-				cb.setValue(
-					this.plugin.settings.sortByChapterProgress
-				).onChange((toggle) => {
-					this.plugin.settings.sortByChapterProgress = toggle;
-					this.plugin.saveSettings();
-				});
-			});
-	}
+    add_enable_creation_date(): void {
+        new Setting(this.containerEl)
+            .setName("Add creation date")
+            .setDesc(`If the exported higlights should include '- [[${this.plugin.settings.dateFormat}]]'`)
+            .addToggle((cb) => {
+                cb.setValue(this.plugin.settings.sortByChapterProgress)
+                    .onChange((toggle) => {
+                        this.plugin.settings.sortByChapterProgress = toggle;
+                        this.plugin.saveSettings();
+                    })
+            })
+    }
 
-	add_date_format(): void {
-		new Setting(this.containerEl)
-			.setName("Date format")
-			.setDesc("The format of date to use")
-			.addMomentFormat((cb) => {
-				cb.setPlaceholder("YYYY-MM-DD")
-					.setValue(this.plugin.settings.dateFormat)
-					.onChange((format) => {
-						this.plugin.settings.dateFormat = format;
-						this.plugin.saveSettings();
-					});
-			});
-	}
+    add_date_format(): void {
+        new Setting(this.containerEl)
+            .setName("Date format")
+            .setDesc("The format of date to use")
+            .addMomentFormat((cb) => {
+                cb.setPlaceholder("YYYY-MM-DD")
+                    .setValue(this.plugin.settings.dateFormat)
+                    .onChange((format) => {
+                        this.plugin.settings.dateFormat = format;
+                        this.plugin.saveSettings();
+                    })
+            })
+    }
 
-	add_sort_by_chapter_progress(): void {
-		const desc = document.createDocumentFragment();
-		desc.append(
-			"Turn on to sort highlights by chapter progess. If turned off, highlights are sorted by creation date and time."
-		);
+    add_sort_by_chapter_progress(): void {
+        const desc = document.createDocumentFragment();
+        desc.append("Turn on to sort highlights by chapter progess. If turned off, highlights are sorted by creation date and time.")
 
-		new Setting(this.containerEl)
-			.setName("Sort by chapter progress")
-			.setDesc(desc)
-			.addToggle((cb) => {
-				cb.setValue(
-					this.plugin.settings.sortByChapterProgress
-				).onChange((toggle) => {
-					this.plugin.settings.sortByChapterProgress = toggle;
-					this.plugin.saveSettings();
-				});
-			});
-	}
-	add_enable_callouts(): void {
-		const desc = document.createDocumentFragment();
-		desc.append(
-			"When enabled Kobo highlights importer will make use of Obsidian callouts for highlights and annotations.",
-			desc.createEl("br"),
-			"When disabled standard markdown block quotes will be used for highlights only.",
-			desc.createEl("br"),
-			"Check the ",
-			desc.createEl("a", {
-				href: "https://help.obsidian.md/How+to/Use+callouts",
-				text: "documentation",
-			}),
-			" to get a list of all available callouts that obsidian offers."
-		);
+        new Setting(this.containerEl)
+            .setName("Sort by chapter progress")
+            .setDesc(desc)
+            .addToggle((cb) => {
+                cb.setValue(this.plugin.settings.sortByChapterProgress)
+                    .onChange((toggle) => {
+                        this.plugin.settings.sortByChapterProgress = toggle;
+                        this.plugin.saveSettings();
+                    });
+            })
+    }
+    add_enable_callouts(): void {
+        const desc = document.createDocumentFragment();
+        desc.append("When enabled Kobo highlights importer will make use of Obsidian callouts for highlights and annotations.",
+        desc.createEl("br"),
+        "When disabled standard markdown block quotes will be used for highlights only.",
+          desc.createEl("br"),
+          "Check the ",
+          desc.createEl("a", {
+            href: "https://help.obsidian.md/How+to/Use+callouts",
+            text: "documentation"
+          }),
+        " to get a list of all available callouts that obsidian offers.");
 
-		new Setting(this.containerEl)
-			.setName("Use Callouts")
-			.setDesc(desc)
-			.addToggle((cb) => {
-				cb.setValue(this.plugin.settings.includeCallouts).onChange(
-					(toggle) => {
-						this.plugin.settings.includeCallouts = toggle;
-						this.plugin.saveSettings();
-					}
-				);
-			});
-	}
+        new Setting(this.containerEl)
+            .setName("Use Callouts")
+            .setDesc(desc)
+            .addToggle((cb) => {
+                cb.setValue(this.plugin.settings.includeCallouts)
+                    .onChange((toggle) => {
+                        this.plugin.settings.includeCallouts = toggle;
+                        this.plugin.saveSettings();
+                    });
+            });
+    }
 
-	add_highlight_callouts_format(): void {
-		new Setting(this.containerEl)
-			.setName("Highlight callout format")
-			.setDesc(`The callout to use for highlights.`)
-			.addText((cb) => {
-				cb.setPlaceholder("quote")
-					.setValue(this.plugin.settings.highlightCallout)
-					.onChange(async (toggle) => {
-						this.plugin.settings.highlightCallout = toggle;
-						await this.plugin.saveSettings();
-					});
-			});
-	}
+    add_highlight_callouts_format(): void {
+        new Setting(this.containerEl)
+            .setName("Highlight callout format")
+            .setDesc(`The callout to use for highlights.`)
+            .addText((cb) => {
+                cb.setPlaceholder("quote")
+                    .setValue(this.plugin.settings.highlightCallout)
+                    .onChange(async (toggle) => {
+                        this.plugin.settings.highlightCallout = toggle;
+                        await this.plugin.saveSettings();
+                    });
+            });
+    }
 
-	add_annotation_callouts_format(): void {
-		new Setting(this.containerEl)
-			.setName("Annotation callout format")
-			.setDesc(`The callout to use for annotations.`)
-			.addText((cb) => {
-				cb.setPlaceholder("note")
-					.setValue(this.plugin.settings.annotationCallout)
-					.onChange(async (toggle) => {
-						this.plugin.settings.annotationCallout = toggle;
-						await this.plugin.saveSettings();
-					});
-			});
-	}
+    add_annotation_callouts_format(): void {
+        new Setting(this.containerEl)
+            .setName("Annotation callout format")
+            .setDesc(`The callout to use for annotations.`)
+            .addText((cb) => {
+                cb.setPlaceholder("note")
+                    .setValue(this.plugin.settings.annotationCallout)
+                    .onChange(async (toggle) => {
+                        this.plugin.settings.annotationCallout = toggle;
+                        await this.plugin.saveSettings();
+                    });
+            });
+    }
 }

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -1,4 +1,4 @@
-import {App, Notice, PluginSettingTab, Setting} from "obsidian";
+import { App, Notice, PluginSettingTab, Setting } from "obsidian";
 import KoboHighlightsImporter from "src/main";
 import { FileSuggestor } from "./suggestors/FileSuggestor";
 import { FolderSuggestor } from "./suggestors/FolderSuggestor";
@@ -7,66 +7,78 @@ import fs from "fs";
 export const DEFAULT_SETTINGS: KoboHighlightsImporterSettings = {
 	enableKobo: false,
 	enableAppleBooks: false,
-	koboSqlitePath: '',
-    storageFolder: '',
-    includeCreatedDate: false,
-    dateFormat: "YYYY-MM-DD",
-    sortByChapterProgress: false,
-    templatePath: "",
-    includeCallouts: true,
-    highlightCallout: "quote",
-    annotationCallout: "note",
-}
+	enableMoonreader: false,
+	koboSqlitePath: "",
+	moonreaderSqlitePath: "",
+	storageFolder: "",
+	includeCreatedDate: false,
+	dateFormat: "YYYY-MM-DD",
+	sortByChapterProgress: false,
+	templatePath: "",
+	includeCallouts: true,
+	highlightCallout: "quote",
+	annotationCallout: "note",
+};
 
 export interface KoboHighlightsImporterSettings {
 	enableKobo: boolean;
 	enableAppleBooks: boolean;
+	enableMoonreader: boolean;
 	koboSqlitePath: string;
-    storageFolder: string;
-    includeCreatedDate: boolean;
-    dateFormat: string;
-    sortByChapterProgress: boolean;
-    templatePath: string;
-    includeCallouts: boolean,
-    highlightCallout: string,
-    annotationCallout: string,
+	moonreaderSqlitePath: string;
+	storageFolder: string;
+	includeCreatedDate: boolean;
+	dateFormat: string;
+	sortByChapterProgress: boolean;
+	templatePath: string;
+	includeCallouts: boolean;
+	highlightCallout: string;
+	annotationCallout: string;
 }
 
 export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
-    constructor(public app: App, private plugin: KoboHighlightsImporter) {
-        super(app, plugin);
-    }
+	constructor(public app: App, private plugin: KoboHighlightsImporter) {
+		super(app, plugin);
+	}
 
-    display(): void {
-        this.containerEl.empty();
+	display(): void {
+		this.containerEl.empty();
 
-		new Setting(this.containerEl).setName('Highlight Extraction').setHeading();
-		this.containerEl.createEl('p', { text: "Configure the data sources from which you will pull highlights." })
-		this.add_kobo_path()
-		this.add_apple_books()
+		new Setting(this.containerEl)
+			.setName("Highlight Extraction")
+			.setHeading();
+		this.containerEl.createEl("p", {
+			text: "Configure the data sources from which you will pull highlights.",
+		});
+		this.add_kobo_path();
+		this.add_apple_books();
+		this.add_moonreader_path();
 
-		new Setting(this.containerEl).setName('Output').setHeading();
-		this.containerEl.createEl('p', { text: "Configure how the highlights will output in Obsidian." })
-        this.add_destination_folder();
-        this.add_enable_creation_date();
-        this.add_date_format();
-        this.add_template_path();
-        this.add_sort_by_chapter_progress();
-        this.add_enable_callouts();
-        this.add_highlight_callouts_format();
-        this.add_annotation_callouts_format();
-    }
+		new Setting(this.containerEl).setName("Output").setHeading();
+		this.containerEl.createEl("p", {
+			text: "Configure how the highlights will output in Obsidian.",
+		});
+		this.add_destination_folder();
+		this.add_enable_creation_date();
+		this.add_date_format();
+		this.add_template_path();
+		this.add_sort_by_chapter_progress();
+		this.add_enable_callouts();
+		this.add_highlight_callouts_format();
+		this.add_annotation_callouts_format();
+	}
 
 	add_kobo_path(): void {
 		new Setting(this.containerEl)
 			.setName("Enable Kobo extractor")
 			.addToggle((toggle) => {
-				toggle.setValue(this.plugin.settings.enableKobo)
+				toggle
+					.setValue(this.plugin.settings.enableKobo)
 					.onChange((value) => {
 						this.plugin.settings.enableKobo = value;
 						this.plugin.saveSettings();
-					})
-			})
+					});
+			});
 
 		new Setting(this.containerEl)
 			.setName("Kobo DB filepath")
@@ -78,14 +90,15 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 					.onChange(async (value) => {
 						fs.access(value, fs.constants.R_OK, (err) => {
 							if (err) {
-								new Notice('Selected file is not readable')
+								new Notice("Selected file is not readable");
 							} else {
-								this.plugin.settings.koboSqlitePath = value
+								this.plugin.settings.koboSqlitePath = value;
 								this.plugin.saveSettings();
-								new Notice('Ready to extract!')
+								new Notice("Ready to extract!");
 							}
-						})
-					}));
+						});
+					})
+			);
 	}
 
 	add_apple_books(): void {
@@ -93,136 +106,180 @@ export class KoboHighlightsImporterSettingsTab extends PluginSettingTab {
 			.setName("Enable Apple Books extractor")
 			.setDesc("Apple Books extraction is only compatible with macOS")
 			.addToggle((toggle) => {
-				toggle.setValue(this.plugin.settings.enableAppleBooks)
+				toggle
+					.setValue(this.plugin.settings.enableAppleBooks)
 					.onChange((value) => {
 						this.plugin.settings.enableAppleBooks = value;
 						this.plugin.saveSettings();
-					})
-			})
+					});
+			});
 	}
 
-    add_destination_folder(): void {
-        new Setting(this.containerEl)
-            .setName('Destination folder')
-            .setDesc('Where to save your imported highlights')
-            .addSearch((cb) => {
-                new FolderSuggestor(this.app, cb.inputEl);
-                cb.setPlaceholder("Example: folder1/folder2")
-                    .setValue(this.plugin.settings.storageFolder)
-                    .onChange((newFolder) => {
-                        this.plugin.settings.storageFolder = newFolder;
-                        this.plugin.saveSettings();
-                    });
-            });
-    }
+	add_moonreader_path(): void {
+		new Setting(this.containerEl)
+			.setName("Enable MoonReader extractor")
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.enableMoonreader)
+					.onChange((value) => {
+						this.plugin.settings.enableMoonreader = value;
+						this.plugin.saveSettings();
+					});
+			});
 
-    add_template_path(): void {
-        new Setting(this.containerEl)
-            .setName('Template Path')
-            .setDesc('Which template to use for extracted highlights')
-            .addSearch((cb) => {
-                new FileSuggestor(this.app, cb.inputEl);
-                cb.setPlaceholder("Example: folder1/template")
-                    .setValue(this.plugin.settings.templatePath)
-                    .onChange((newTemplatePath) => {
-                        this.plugin.settings.templatePath = newTemplatePath;
-                        this.plugin.saveSettings();
-                    });
-            });
-    }
+		new Setting(this.containerEl)
+			.setName("Moon+Reader DB filepath")
+			.setDesc("Path to the moonreader db on your system.")
+			.addText((text) =>
+				text
+					.setPlaceholder("")
+					.setValue(this.plugin.settings.moonreaderSqlitePath)
+					.onChange(async (value) => {
+						fs.access(value, fs.constants.R_OK, (err) => {
+							if (err) {
+								new Notice("Selected file is not readable");
+							} else {
+								this.plugin.settings.moonreaderSqlitePath =
+									value;
+								this.plugin.saveSettings();
+								new Notice("Ready to extract!");
+							}
+						});
+					})
+			);
+	}
 
-    add_enable_creation_date(): void {
-        new Setting(this.containerEl)
-            .setName("Add creation date")
-            .setDesc(`If the exported higlights should include '- [[${this.plugin.settings.dateFormat}]]'`)
-            .addToggle((cb) => {
-                cb.setValue(this.plugin.settings.sortByChapterProgress)
-                    .onChange((toggle) => {
-                        this.plugin.settings.sortByChapterProgress = toggle;
-                        this.plugin.saveSettings();
-                    })
-            })
-    }
+	add_destination_folder(): void {
+		new Setting(this.containerEl)
+			.setName("Destination folder")
+			.setDesc("Where to save your imported highlights")
+			.addSearch((cb) => {
+				new FolderSuggestor(this.app, cb.inputEl);
+				cb.setPlaceholder("Example: folder1/folder2")
+					.setValue(this.plugin.settings.storageFolder)
+					.onChange((newFolder) => {
+						this.plugin.settings.storageFolder = newFolder;
+						this.plugin.saveSettings();
+					});
+			});
+	}
 
-    add_date_format(): void {
-        new Setting(this.containerEl)
-            .setName("Date format")
-            .setDesc("The format of date to use")
-            .addMomentFormat((cb) => {
-                cb.setPlaceholder("YYYY-MM-DD")
-                    .setValue(this.plugin.settings.dateFormat)
-                    .onChange((format) => {
-                        this.plugin.settings.dateFormat = format;
-                        this.plugin.saveSettings();
-                    })
-            })
-    }
+	add_template_path(): void {
+		new Setting(this.containerEl)
+			.setName("Template Path")
+			.setDesc("Which template to use for extracted highlights")
+			.addSearch((cb) => {
+				new FileSuggestor(this.app, cb.inputEl);
+				cb.setPlaceholder("Example: folder1/template")
+					.setValue(this.plugin.settings.templatePath)
+					.onChange((newTemplatePath) => {
+						this.plugin.settings.templatePath = newTemplatePath;
+						this.plugin.saveSettings();
+					});
+			});
+	}
 
-    add_sort_by_chapter_progress(): void {
-        const desc = document.createDocumentFragment();
-        desc.append("Turn on to sort highlights by chapter progess. If turned off, highlights are sorted by creation date and time.")
+	add_enable_creation_date(): void {
+		new Setting(this.containerEl)
+			.setName("Add creation date")
+			.setDesc(
+				`If the exported higlights should include '- [[${this.plugin.settings.dateFormat}]]'`
+			)
+			.addToggle((cb) => {
+				cb.setValue(
+					this.plugin.settings.sortByChapterProgress
+				).onChange((toggle) => {
+					this.plugin.settings.sortByChapterProgress = toggle;
+					this.plugin.saveSettings();
+				});
+			});
+	}
 
-        new Setting(this.containerEl)
-            .setName("Sort by chapter progress")
-            .setDesc(desc)
-            .addToggle((cb) => {
-                cb.setValue(this.plugin.settings.sortByChapterProgress)
-                    .onChange((toggle) => {
-                        this.plugin.settings.sortByChapterProgress = toggle;
-                        this.plugin.saveSettings();
-                    });
-            })
-    }
-    add_enable_callouts(): void {
-        const desc = document.createDocumentFragment();
-        desc.append("When enabled Kobo highlights importer will make use of Obsidian callouts for highlights and annotations.",
-        desc.createEl("br"),
-        "When disabled standard markdown block quotes will be used for highlights only.",
-          desc.createEl("br"),
-          "Check the ",
-          desc.createEl("a", {
-            href: "https://help.obsidian.md/How+to/Use+callouts",
-            text: "documentation"
-          }),
-        " to get a list of all available callouts that obsidian offers.");
+	add_date_format(): void {
+		new Setting(this.containerEl)
+			.setName("Date format")
+			.setDesc("The format of date to use")
+			.addMomentFormat((cb) => {
+				cb.setPlaceholder("YYYY-MM-DD")
+					.setValue(this.plugin.settings.dateFormat)
+					.onChange((format) => {
+						this.plugin.settings.dateFormat = format;
+						this.plugin.saveSettings();
+					});
+			});
+	}
 
-        new Setting(this.containerEl)
-            .setName("Use Callouts")
-            .setDesc(desc)
-            .addToggle((cb) => {
-                cb.setValue(this.plugin.settings.includeCallouts)
-                    .onChange((toggle) => {
-                        this.plugin.settings.includeCallouts = toggle;
-                        this.plugin.saveSettings();
-                    });
-            });
-    }
+	add_sort_by_chapter_progress(): void {
+		const desc = document.createDocumentFragment();
+		desc.append(
+			"Turn on to sort highlights by chapter progess. If turned off, highlights are sorted by creation date and time."
+		);
 
-    add_highlight_callouts_format(): void {
-        new Setting(this.containerEl)
-            .setName("Highlight callout format")
-            .setDesc(`The callout to use for highlights.`)
-            .addText((cb) => {
-                cb.setPlaceholder("quote")
-                    .setValue(this.plugin.settings.highlightCallout)
-                    .onChange(async (toggle) => {
-                        this.plugin.settings.highlightCallout = toggle;
-                        await this.plugin.saveSettings();
-                    });
-            });
-    }
+		new Setting(this.containerEl)
+			.setName("Sort by chapter progress")
+			.setDesc(desc)
+			.addToggle((cb) => {
+				cb.setValue(
+					this.plugin.settings.sortByChapterProgress
+				).onChange((toggle) => {
+					this.plugin.settings.sortByChapterProgress = toggle;
+					this.plugin.saveSettings();
+				});
+			});
+	}
+	add_enable_callouts(): void {
+		const desc = document.createDocumentFragment();
+		desc.append(
+			"When enabled Kobo highlights importer will make use of Obsidian callouts for highlights and annotations.",
+			desc.createEl("br"),
+			"When disabled standard markdown block quotes will be used for highlights only.",
+			desc.createEl("br"),
+			"Check the ",
+			desc.createEl("a", {
+				href: "https://help.obsidian.md/How+to/Use+callouts",
+				text: "documentation",
+			}),
+			" to get a list of all available callouts that obsidian offers."
+		);
 
-    add_annotation_callouts_format(): void {
-        new Setting(this.containerEl)
-            .setName("Annotation callout format")
-            .setDesc(`The callout to use for annotations.`)
-            .addText((cb) => {
-                cb.setPlaceholder("note")
-                    .setValue(this.plugin.settings.annotationCallout)
-                    .onChange(async (toggle) => {
-                        this.plugin.settings.annotationCallout = toggle;
-                        await this.plugin.saveSettings();
-                    });
-            });
-    }
+		new Setting(this.containerEl)
+			.setName("Use Callouts")
+			.setDesc(desc)
+			.addToggle((cb) => {
+				cb.setValue(this.plugin.settings.includeCallouts).onChange(
+					(toggle) => {
+						this.plugin.settings.includeCallouts = toggle;
+						this.plugin.saveSettings();
+					}
+				);
+			});
+	}
+
+	add_highlight_callouts_format(): void {
+		new Setting(this.containerEl)
+			.setName("Highlight callout format")
+			.setDesc(`The callout to use for highlights.`)
+			.addText((cb) => {
+				cb.setPlaceholder("quote")
+					.setValue(this.plugin.settings.highlightCallout)
+					.onChange(async (toggle) => {
+						this.plugin.settings.highlightCallout = toggle;
+						await this.plugin.saveSettings();
+					});
+			});
+	}
+
+	add_annotation_callouts_format(): void {
+		new Setting(this.containerEl)
+			.setName("Annotation callout format")
+			.setDesc(`The callout to use for annotations.`)
+			.addText((cb) => {
+				cb.setPlaceholder("note")
+					.setValue(this.plugin.settings.annotationCallout)
+					.onChange(async (toggle) => {
+						this.plugin.settings.annotationCallout = toggle;
+						await this.plugin.saveSettings();
+					});
+			});
+	}
 }


### PR DESCRIPTION
Moon+ Reader is an ereader app for android ( https://www.moondownload.com/ )

Though it does not provide easy ways to retrieve highlight data, so I had to take advantage of its backup system.
This requires an action from the user inside the app (there is an option to set Auto Backup daily, weekly or monthly- locally or using Dropbox, Google Drive, WebDAV or FTP).
Inside the Moon+Reader app, go to the settings. Scroll all the way down and find the "Backup" button.

This will generate an archive with this format `{date}.mrstd` .

I unzip this archive and look for the relevant sqlite file inside the archive. (All the files are `.tag` so it needs a bit of analysis).
Then I can open the db and work if the info available

## Limitations

Some information is missing compared to the other extractors.
At the time of writing this, I didn't find a practical way to get the chapter names (I only get the chapter numbers).
A lot of information concerning the book is also missing (isbn, etc.)

I decided to let it as is, since it's better than nothing.

I guess it could be possible to retrieve some information from the `.epub` files directly but this is out of scope of this I guess.